### PR TITLE
Add OS X and Linux compatibility

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
     var tokenChecked: boolean = false;
     var gistChecked: boolean = false;
     var tempValue: string = "";
-    var PATH = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : '/var/local');
+    var PATH: string  = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : '/var/local');
     var FILE_GIST: string = PATH.concat("/Code/User/gist_sync.txt");
     var FILE_TOKEN: string = PATH.concat("/Code/User/token.txt");
     var FILE_SETTING: string = PATH.concat("/Code/User/settings.json");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,13 +26,13 @@ export function activate(context: vscode.ExtensionContext) {
     var tokenChecked: boolean = false;
     var gistChecked: boolean = false;
     var tempValue: string = "";
-    var PATH: string = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + 'Library/Preference' : '/var/local');
-    var FILE_GIST: string = PATH.concat("\\Code\\User\\gist_sync.txt");
-    var FILE_TOKEN: string = PATH.concat("\\Code\\User\\token.txt");
-    var FILE_SETTING: string = PATH.concat("\\Code\\User\\settings.json");
-    var FILE_LAUNCH: string = PATH.concat("\\Code\\User\\launch.json");
-    var FILE_KEYBINDING: string = PATH.concat("\\Code\\User\\keybindings.json");
-    var FOLDER_SNIPPETS: string = PATH.concat("\\Code\\User\\snippets\\");
+    var PATH = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : '/var/local');
+    var FILE_GIST = PATH.concat("/Code/User/gist_sync.txt");
+    var FILE_TOKEN = PATH.concat("/Code/User/token.txt");
+    var FILE_SETTING = PATH.concat("/Code/User/settings.json");
+    var FILE_LAUNCH = PATH.concat("/Code/User/launch.json");
+    var FILE_KEYBINDING = PATH.concat("/Code/User/keybindings.json");
+    var FOLDER_SNIPPETS = PATH.concat("/Code/User/snippets/");
     var GIST_JSON: any = {
         "description": "Visual Studio code settings",
         "public": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,12 +27,12 @@ export function activate(context: vscode.ExtensionContext) {
     var gistChecked: boolean = false;
     var tempValue: string = "";
     var PATH = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : '/var/local');
-    var FILE_GIST = PATH.concat("/Code/User/gist_sync.txt");
-    var FILE_TOKEN = PATH.concat("/Code/User/token.txt");
-    var FILE_SETTING = PATH.concat("/Code/User/settings.json");
-    var FILE_LAUNCH = PATH.concat("/Code/User/launch.json");
-    var FILE_KEYBINDING = PATH.concat("/Code/User/keybindings.json");
-    var FOLDER_SNIPPETS = PATH.concat("/Code/User/snippets/");
+    var FILE_GIST: string = PATH.concat("/Code/User/gist_sync.txt");
+    var FILE_TOKEN: string = PATH.concat("/Code/User/token.txt");
+    var FILE_SETTING: string = PATH.concat("/Code/User/settings.json");
+    var FILE_LAUNCH: string = PATH.concat("/Code/User/launch.json");
+    var FILE_KEYBINDING: string = PATH.concat("/Code/User/keybindings.json");
+    var FOLDER_SNIPPETS: string = PATH.concat("/Code/User/snippets/");
     var GIST_JSON: any = {
         "description": "Visual Studio code settings",
         "public": false,


### PR DESCRIPTION
Fix #2 

But the "Download settings" when nothing is configured yet (On a new setup for example) is still not working as before the modification, once this is fixed, everything should work fine.
