### PR TITLE
Cross platform method of determining homedir

### DIFF
--- a/src/pluginService.ts
+++ b/src/pluginService.ts
@@ -8,7 +8,8 @@ var fs = require('fs');
 var ncp = require('ncp').ncp;
 
 var apiPath = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery';
-var ExtensionFolder: string = path.join(process.env.USERPROFILE, '.vscode', 'extensions');
+var homeDir = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME']
+var ExtensionFolder: string = path.join(homeDir, '.vscode', 'extensions');
     
 export class ExtensionInformation{
     metadata: ExtensionMetadata;


### PR DESCRIPTION
Previously only attempting to use Window's specific USERPROFILE env variable to determine home directory, *nix variants use HOME. This allowed the extension to work on OSX for me and should allow the extension to continue working properly on Windows.

Attribution: Method for determining home directory came from this Stack Overflow answer: http://stackoverflow.com/a/9081436